### PR TITLE
Fixing the iOS CI build

### DIFF
--- a/FlightWork/ManagedSimConnect/ManagedSimConnect.csproj
+++ b/FlightWork/ManagedSimConnect/ManagedSimConnect.csproj
@@ -5,11 +5,7 @@
     <RootNamespace>SimConnect</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
Unsafe code settings need to be set for all targets and configurations.